### PR TITLE
add support tab that links to support info in wiki

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
           <div><a href="https://github.com/landlab/landlab/wiki/User-Guide">User Guide</a></div>
           <div><a href="https://github.com/landlab/landlab/wiki/Tutorials">Tutorials</a></div>
           <div><a href="http://landlab.readthedocs.org/en/latest/#developer-documentation">Reference Manual</a></div>
+          <div><a href="https://github.com/landlab/landlab/wiki/FAQs#support-how-can-i-ask-more-questions-and-get-help">Support</a></div>
           <div><a href="https://github.com/landlab/landlab/wiki/FAQs">FAQs</a></div>
           <div><a href="https://github.com/landlab/landlab/wiki/About">More</a></div>
         </nav>


### PR DESCRIPTION
@saisiddu this PR adds a tab to the landing page called Support that links to https://github.com/landlab/landlab/wiki/FAQs#support-how-can-i-ask-more-questions-and-get-help with more specific information about how to file an issue