### PR TITLE
Update of splash page for 2.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,14 +25,12 @@
       <div class="htext">
         <h2 class="tag">a python toolkit for modeling earth surface processes</h2>
         <nav>
-          <!-- <div><a href="https://github.com/landlab/landlab/wiki/Examples">Examples</a></div> -->
           <div><a href="https://landlab.github.io/#/#install">Install</a></div>
-          <div><a href="https://github.com/landlab/landlab/wiki/User-Guide">User Guide</a></div>
-          <div><a href="https://github.com/landlab/landlab/wiki/Tutorials">Tutorials</a></div>
-          <div><a href="http://landlab.readthedocs.org/en/latest/#developer-documentation">Reference Manual</a></div>
-          <div><a href="https://github.com/landlab/landlab/wiki/FAQs#support-how-can-i-ask-more-questions-and-get-help">Support</a></div>
-          <div><a href="https://github.com/landlab/landlab/wiki/FAQs">FAQs</a></div>
-          <div><a href="https://github.com/landlab/landlab/wiki/About">More</a></div>
+          <div><a href="https://landlab.readthedocs.io/en/latest/user_guide/index.html">User Guide</a></div>
+          <div><a href="https://landlab.readthedocs.io/en/latest/user_guide/tutorials.html">Tutorials</a></div>
+          <div><a href="https://landlab.readthedocs.io/en/latest/">Reference Manual</a></div>
+          <div><a href="https://landlab.readthedocs.io/en/latest/#contact">Support</a></div>
+          <div><a href="https://landlab.readthedocs.io/en/latest/#citing-landlab">Cite</a></div>
         </nav>
       </div>
     </div>

--- a/views/home.html
+++ b/views/home.html
@@ -2,39 +2,45 @@
   <div class="white">
     <a name="about"></a><h2>What is <span itemprop="name">Landlab</span>?</h2>
     <p>
-      Landlab is a Python-based modeling environment that allows scientists and students to build numerical
-      landscape models. Designed for disciplines that quantify earth surface dynamics such as
-      geomorphology, hydrology, glaciology, and stratigraphy, it can also
-      be used in related fields.
+      Landlab is a Python-based modeling environment that allows scientists and students to build numerical landscape models. Designed for disciplines that quantify earth surface dynamics such as geomorphology, hydrology, glaciology, and stratigraphy, it can also be used in related fields.
     </p>
     <p>
-      Landlab provides components to compute flows (such as water, sediment, glacial ice, volcanic
-      material, or landslide debris) across a gridded terrain. With its robust, reusable components, Landlab allows
-      scientists to quickly build landscape model experiments and compute mass balance across scales.
+      Landlab provides components to compute flows (such as water, sediment, glacial ice, volcanic material, or landslide debris) across a gridded terrain. With its robust, reusable components, Landlab allows scientists to quickly build landscape model experiments and compute mass balance across scales.
     </p>
     <p>
-      Landlab is described in more detail by Hobley et al. in the 2017 paper <a target="_blank" href="http://www.earth-surf-dynam.net/5/21/2017/esurf-5-21-2017.html">Creative Computing with Landlab</a>.
+      Landlab is described in more detail by Hobley et al. in the 2017 paper <a target="_blank" href="http://www.earth-surf-dynam.net/5/21/2017/esurf-5-21-2017.html">Creative Computing with Landlab</a>. <a target="_blank" href="https://landlab.readthedocs.io/en/v2_dev/#citing-landlab">This part of the documentation</a> describes how to cite Landlab.
     </p>
   </div>
 </div>
+<div class="background">
+  <div class="white">
+    <a name="landlab2"></a><h2>Landlab 2.0</h2>
+    <p>
+      On December 20th, 2019, we transitioned from Landlab 1.11 to Landlab 2.0-beta. This is a breaking change, and it drops support for Python 2 versions. We expect it will have little effect on most users, but if it affects you, please <a target="_blank" href="https://github.com/landlab/landlab/issues">make an issue</a> on GitHub to get help.
+    </p>
+    <p>
+      After the Landlab 2.0-beta version is released, we will not accept pull requests into the 1.0 version. We will keep Landlab 2.0 in beta release until the publication describing this version is published (expected Spring 2020). At that point we will make a final version 2.0.0 release. 2.0-beta is better and more stable than 1.11, it has more features, and its <a href="https://landlab.readthedocs.io/en/latest">documentation</a> has been completely overhauled.
+    </p>
+  </div>
+</div>
+
 <div class="background">
   <div class="white">
     <h2>Examples</h2>
     <p>
       The following models can easily be built with Landlab's current capabilities:
       <li>
-        A <a href="http://nbviewer.ipython.org/github/landlab/tutorials/blob/master/fault_scarp/landlab-fault-scarp.ipynb" target="_blank">landscape evolution model</a> using linear diffusion and the stream-power model
+        A <a href="https://mybinder.org/v2/gh/landlab/landlab/release?filepath=notebooks/tutorials/fault_scarp/landlab-fault-scarp.ipynb" target="_blank">landscape evolution model</a> using linear diffusion and the stream-power model
       </li>
       <li>
-        A model that explores the <a href="http://nbviewer.ipython.org/github/landlab/tutorials/blob/master/flexure/lots_of_loads.ipynb" target="_blank">flexural response</a> to the growth and recession of glaciers
-      </li>
-      <li>
-        An <a href="https://raw.githubusercontent.com/wiki/landlab/landlab/images/Sai_AGU_2015.jpg" target="_blank">ecohydrology model</a> in which vegetation on two sides of a valley grows and dies in response to stochastic storms and solar forcing throughout the year
+        A model that explores the <a href="https://mybinder.org/v2/gh/landlab/landlab/release?filepath=notebooks/tutorials/flexure/lots_of_loads.ipynb" target="_blank">flexural response</a> to the growth and recession of glaciers
       </li>
       <li>
         A model that <a href="https://www.youtube.com/watch?v=4Ltr6HRUrQI" target="_blank">routes hydrographs across a watershed</a> based on rainfall inputs
       </li>
-
+    </p>
+    <p>
+      See <a href="https://mybinder.org/v2/gh/landlab/landlab/release?filepath=notebooks/welcome.ipynb" target="_blank">this page</a> for an index of all available Jupyter notebooks for research and teaching built with Landlab.
     </p>
   </div>
 </div>
@@ -43,19 +49,14 @@
     <a name="install"></a><h2>Installing Landlab</h2>
     <p>
       To install Landlab, you will need a Python distribution that includes
-          <li>Python 2.6+ or 3.5+ (NB: support for Python 2 will be dropped in Landlab v.2)</li>
-          <li>NumPy 1.9 or greater</li>
-          <li>SciPy 0.14 or greater</li>
-          <li>netCDF4 (will run without, but recommended)</li>
-          <li>Cython (only required if building Landlab from source code)</li>
+          <li>Python 3.5+</li>
           <li>an up-to-date Python package manager (such as conda or PyPI, aka "pip")</li>
-          <li>a compiler that Python can recognise (through the Xcode app on a mac)</li>
     </p>
 
     <p> To fulfill these requirements we recommend a preassembled scientific Python
     distribution such as <a href="https://www.anaconda.com/distribution/">Continuum
-    IO’s Anaconda.</a> We recommend choosing <strong>Python 3</strong> over
-    Python 2 when offered the choice.
+    IO’s Anaconda.</a>
+
     As well as the Python package and associated libraries, the Anaconda
     installer also puts a suite of useful Python tools on your machine, including
     a graphical interface for coding. However, what we are mostly after is
@@ -74,111 +75,8 @@
      You need to choose between two installation options for Landlab at this stage:
    </p>
    <p>
-		 <li>Using Anaconda - installation of a pre-compiled Landlab release. It's quick and easy but you will not be able to access and edit the code itself.</li>
-		 <li>Developer Installation - forking Landlab's github repository. This is the preferred option if you want to modify code and commit back to Landlab.</li>
+		 <li><a href="https://landlab.readthedocs.io/en/v2_dev/install/index.html">Precompiled version</a> - installation of a pre-compiled Landlab release. It's quick and easy but you will not be able to access and edit the code itself. You will be able to mix and match Landlab components and change paramter values. If you are uncertain, this is the choice you want.</li>
+		 <li><a href="https://landlab.readthedocs.io/en/v2_dev/development/install/index.html">Developer Installation</a> - forking Landlab's Github repository and installing from source code. This is the preferred option if you want to modify code and commit back to Landlab. If you choose this option, please also check out the <a href="https://landlab.readthedocs.io/en/v2_dev/development/index.html">Landlab guide for developers</a>.</li>
    </p>
-   <p>
-     We anticipate most users will want to choose an Anaconda install, at least while becoming familiar with Landlab.
-   </p>
-
-   <h3>Installing Landlab Using Anaconda</h3>
-   <p>
-     We recommend running Landlab inside its own conda environment. This keeps it from interfering with any other Python software you may have on your machine.
-   </p>
-   <p>
-     To do this, open a terminal (or, on a PC, the command prompt—make sure it is a true DOS "cmd" prompt, not, e.g., Cygwin) and type the following:
-   </p>
-   <p>
-     <code>> conda create -n landlab_env landlab -c conda-forge</code>
-   </p>
-   <p>
-     You can now activate this environment and use Landlab inside it. Do this with:
-   </p>
-   <p>
-     <code>> conda activate landlab_env</code>
-   </p>
-   <p>
-     And proceed to use Landlab. When you're done, close up your environment with:
-   </p>
-   <p>
-     <code>> conda deactivate</code>
-   </p>
-   <p>
-     There are also two install options we don't formally recommend. You can still install Landlab directly without an environment using
-     <code>conda install landlab -c conda-forge</code>,
-     and there is also an up-to-date <code>pip</code> distribution for users who would prefer that.
-   </p>
-   <p>
-     More detailed instructions for installing Landlab with Anaconda's Python distribution are available in the <a href="https://landlab.readthedocs.io/en/v2_dev/install/index.html">reference manual</a>.
-   </p>
-
-   <h3>
-     Developer Installation—Installing from Landlab Source Code
-   </h3>
-   <p>
-     For users who have gotten a feel for Landlab and want to
-     keep up with the absolute latest Landlab developments and contribute code back to the Landlab repository,
-     <a href="https://landlab.readthedocs.io/en/v2_dev/development/install/index.html">these directions</a> are available as part of the <a href="https://landlab.readthedocs.io/en/v2_dev/development/index.html">Landlab guide for developers</a>.
-   </p>
-  </div>
-</div>
-
-<div class="background">
-  <div class="white">
-    <a name="update"></a><h2>Updating Landlab</h2>
-
-    <p>
-      As Landlab is still relatively early in its development
-      cycle, the code will update fairly frequently with new releases.
-      To take advantage of new features and new library
-      additions (as well as bug fixes, <i>ahem</i>), we recommend you update Landlab regularly.
-    </p>
-
-    <p>
-      Whenever you update Landlab, we strongly recommend you <strong>also update your
-      Python package!</strong> For Anaconda, use the <code>conda</code> package manager from a command
-      prompt.
-      Assuming you have Landlab installed in a conda environment, be sure to activate the environment first.
-      [Remember, on a PC, do all this in a Command Prompt window or through Anaconda; do not use Cygwin.]
-    </p>
-    <p>
-      <code>
-        > conda update --all
-      </code>
-    </p>
-    <p>
-      Once you've done this, simply update landlab, once again specifically from the <code>conda-forge</code> conda channel:
-    </p>
-    <p>
-      <code>
-        > conda update landlab -c conda-forge
-      </code>
-    </p>
-    <h3>
-      Older Installations of Landlab
-    </h3>
-    <p>
-      We used to recommend installing landlab outside an environment, using either the <code>pip</code> package manager or through a conda channel called <code>-c landlab</code>. Notably, if you installed through the conda <code>landlab</code> channel rather than <code>conda-forge</code>, you won't be able to access updates any more. If you're now using Landlab inside its own environment, having these older versions around won't matter too much. However, to minimise confusion, you may wish to remove them. Simply do this:
-    </p>
-    <p>
-      <code>
-        > pip uninstall landlab
-      </code>
-    </p>
-    <p>
-      and/or
-    </p>
-    <p>
-      <code>
-        > conda uninstall landlab
-      </code>
-    </p>
-    <p>
-      from outside your environment. The Landlab installation inside your environment should be unaffected.
-    </p>
-    <p>
-      If you have <a href="https://github.com/landlab/landlab/wiki/Updating-Landlab" target="_blank">errors during install, click here</a> for guidance on how to resolve them.
-    </p>
-
   </div>
 </div>


### PR DESCRIPTION
- points to new documentation
- no longer points to the wiki
- removes install instructions from splash page and points users to the docs (so we have 1 place for regular and 1 place for dev were we maintain install/update instructions)
- points to binder

some links may be broken temporarily until the final LL2.0 release happens (later today likely)