### PR TITLE
Update links to the landlab docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,11 +28,11 @@
         <h2 class="tag">a python toolkit for modeling earth surface processes</h2>
         <nav>
           <div><a href="https://landlab.github.io/#/#install">Install</a></div>
-          <div><a href="https://landlab.readthedocs.io/en/latest/user_guide/index.html">User Guide</a></div>
-          <div><a href="https://landlab.readthedocs.io/en/latest/user_guide/tutorials.html">Tutorials</a></div>
-          <div><a href="https://landlab.readthedocs.io/en/latest/">Reference Manual</a></div>
-          <div><a href="https://landlab.readthedocs.io/en/latest/#contact">Support</a></div>
-          <div><a href="https://landlab.readthedocs.io/en/latest/#citing-landlab">Cite</a></div>
+          <div><a href="https://landlab.csdms.io/en/latest/user_guide/index.html">User Guide</a></div>
+          <div><a href="https://landlab.csdms.io/en/latest/user_guide/tutorials.html">Tutorials</a></div>
+          <div><a href="https://landlab.csdms.io/en/latest/">Reference Manual</a></div>
+          <div><a href="https://landlab.csdms.io/en/latest/#contact">Support</a></div>
+          <div><a href="https://landlab.csdms.io/en/latest/#citing-landlab">Cite</a></div>
         </nav>
       </div>
     </div>

--- a/views/home.html
+++ b/views/home.html
@@ -8,10 +8,10 @@
       Landlab provides components to compute flows (such as water, sediment, glacial ice, volcanic material, or landslide debris) across a gridded terrain. With its robust, reusable components, Landlab allows scientists to quickly build landscape model experiments and compute mass balance across scales.
     </p>
     <p>
-      Our source code is hosted on <a target="_blank" href="https://github.com/landlab/landlab">GitHub</a> and our documentation is hosted on <a target="_blank" href="https://landlab.readthedocs.io/en/latest/">ReadTheDocs</a>.
+      Our source code is hosted on <a target="_blank" href="https://github.com/landlab/landlab">GitHub</a> and our documentation is hosted on <a target="_blank" href="https://landlab.csdms.io/en/latest/">ReadTheDocs</a>.
     </p>
     <p>
-      Landlab is described in more detail by Hobley et al. in the 2017 paper <a target="_blank" href="http://www.earth-surf-dynam.net/5/21/2017/esurf-5-21-2017.html">Creative Computing with Landlab</a> and in Barnhart et al. in the 2020 paper <a target="_blank" href="https://doi.org/10.5194/esurf-8-379-2020">Short communication: Landlab v2.0</a>. If you use Landlab in your work, please cite these papers. <a target="_blank" href="https://landlab.readthedocs.io/en/latest/#citing-landlab">This part of the documentation</a> describes how to cite Landlab.
+      Landlab is described in more detail by Hobley et al. in the 2017 paper <a target="_blank" href="http://www.earth-surf-dynam.net/5/21/2017/esurf-5-21-2017.html">Creative Computing with Landlab</a> and in Barnhart et al. in the 2020 paper <a target="_blank" href="https://doi.org/10.5194/esurf-8-379-2020">Short communication: Landlab v2.0</a>. If you use Landlab in your work, please cite these papers. <a target="_blank" href="https://landlab.csdms.io/en/latest/#citing-landlab">This part of the documentation</a> describes how to cite Landlab.
     </p>
   </div>
 </div>
@@ -56,8 +56,8 @@
      You need to choose between two installation options for Landlab at this stage:
    </p>
    <p>
-		 <li><a href="https://landlab.readthedocs.io/en/master/installation.html">Precompiled version</a> - installation of a pre-compiled Landlab release. It's quick and easy but you will not be able to access and edit the code itself. You will be able to mix and match Landlab components and change paramter values. If you are uncertain, this is the choice you want.</li>
-		 <li><a href="https://landlab.readthedocs.io/en/master/install/index.html">Developer Installation</a> - forking Landlab's Github repository and installing from source code. This is the preferred option if you want to modify code and commit back to Landlab. If you choose this option, please also check out the <a href="https://landlab.readthedocs.io/en/latest/development/index.html">Landlab guide for developers</a>.</li>
+		 <li><a href="https://landlab.csdms.io/en/master/installation.html">Precompiled version</a> - installation of a pre-compiled Landlab release. It's quick and easy but you will not be able to access and edit the code itself. You will be able to mix and match Landlab components and change paramter values. If you are uncertain, this is the choice you want.</li>
+		 <li><a href="https://landlab.csdms.io/en/master/install/index.html">Developer Installation</a> - forking Landlab's Github repository and installing from source code. This is the preferred option if you want to modify code and commit back to Landlab. If you choose this option, please also check out the <a href="https://landlab.readthedocs.io/en/latest/development/index.html">Landlab guide for developers</a>.</li>
    </p>
   </div>
 </div>


### PR DESCRIPTION
The *Landlab* documentation has moved from *landlab.readthedocs.io* to *landlab.csdms.io*.