### PR TITLE
Add redirect to landlab.csdms.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html> <html lang="en" ng-app="landlab"> <head> <meta charset="UTF-8">
 <title>Landlab | a python toolkit for modeling earth surface processes </title>
+  <meta http-equiv="Refresh" content="0; url='https://landlab.csdms.io'"/>
   <meta property="og:url" content="http://landlab.github.io"/>
   <meta property="og:title" content="Landlab | a python toolkit for modeling earth surface processes"/>
   <meta property="og:image" content="http://landlab.github.io/assets/Landlab-logo.png"/>


### PR DESCRIPTION
We would like users to go to our new *Landlab* site at [landlab.csdms.io](https://landlab.csdms.io) so I've added a redirect to `index.html`.

@gregtucker Do you think this is sufficient?